### PR TITLE
Changed superclass of SpDragHere

### DIFF
--- a/src/Durden/SpDragHere.class.st
+++ b/src/Durden/SpDragHere.class.st
@@ -6,7 +6,7 @@ I cannot be shown by my self, but i can be embedded into different containers.
 "
 Class {
 	#name : #SpDragHere,
-	#superclass : #SpContainerPresenter,
+	#superclass : #SpAbstractWidgetPresenter,
 	#instVars : [
 		'dropInto'
 	],


### PR DESCRIPTION
SpContainerPresenter has been removed from Pharo 10.
SpAbstractWidgetPresenter provides the API needed to manage drop.